### PR TITLE
README clarification

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -14,7 +14,7 @@ Projects for Trello is a Chrome Extension that adds a little bit of functionalit
 to Trello.com to make it perfect to use with multiple projects. Projects for Trello
 allows you to add project labels to cards.
 
-Project names are written in between parentheses in the title of a card.
+Project names are written in between braces in the title of a card.
 For example: {Project} Upon an error I want to see an awesome 404 page.
 Upon saving the card, Projects for Trello picks up the assigned project name and shows it
 as a badge in the lower left corner of the card. Projects for Trello also supports multiple labels per card.


### PR DESCRIPTION
The README mentions that projects should be surrounded by parentheses `()` but the extension actually uses braces `{}`